### PR TITLE
Add SetProtocol to user local communication | Fix Animal Crossing 3.0.0 LDN

### DIFF
--- a/ldn_mitm/source/interfaces/icommunication.hpp
+++ b/ldn_mitm/source/interfaces/icommunication.hpp
@@ -17,6 +17,7 @@
         AMS_SF_METHOD_INFO(C, H, 102, Result, Scan, 				   (ams::sf::Out<u32> count, ams::sf::OutAutoSelectArray<ams::mitm::ldn::NetworkInfo> buffer, u16 channel, ams::mitm::ldn::ScanFilter filter), 	(count, buffer, channel, filter))	\
  /*nyi*/AMS_SF_METHOD_INFO(C, H, 103, Result, ScanPrivate, 			   (), 																																			())									\
  /*nyi*/AMS_SF_METHOD_INFO(C, H, 104, Result, SetWirelessControllerRestriction, (), 																																			())									\
+ /*nyi*/AMS_SF_METHOD_INFO(C, H, 106, Result, SetProtocol, 			   (u32 protocol), 																																(protocol))							\
         AMS_SF_METHOD_INFO(C, H, 200, Result, OpenAccessPoint, 		   (), 																																			())									\
         AMS_SF_METHOD_INFO(C, H, 201, Result, CloseAccessPoint, 		   (), 																																			())									\
         AMS_SF_METHOD_INFO(C, H, 202, Result, CreateNetwork, 			   (ams::mitm::ldn::CreateNetworkConfig data), 																									(data))								\

--- a/ldn_mitm/source/ldn_icommunication.cpp
+++ b/ldn_mitm/source/ldn_icommunication.cpp
@@ -186,6 +186,25 @@ namespace ams::mitm::ldn {
         return 0;
     }
 
+    Result ICommunicationService::SetProtocol(u32 protocol) {
+        LogFormat("SetProtocol called, protocol=%u", protocol);
+        
+        // Normalize protocol according to Nintendo documentation
+        // SDK passes 1 when input protocol is 0 or 1
+        // Value 3 is passed directly if specified
+        if (protocol == 0 || protocol == 1) {
+            this->m_protocol = 1;  // NX protocol
+        } else if (protocol == 3) {
+            this->m_protocol = 3;  // S2 protocol (Switch 2)
+        } else {
+            LogFormat("SetProtocol: Invalid protocol %u, defaulting to 1", protocol);
+            this->m_protocol = 1;
+        }
+        
+        LogFormat("SetProtocol: Protocol set to %u", this->m_protocol);
+        return 0;
+    }
+
     Result ICommunicationService::ScanPrivate() {
         return 0;
     }

--- a/ldn_mitm/source/ldn_icommunication.hpp
+++ b/ldn_mitm/source/ldn_icommunication.hpp
@@ -29,8 +29,9 @@ namespace ams::mitm::ldn {
             LANDiscovery lanDiscovery;
             os::SystemEvent *state_event;
             u64 error_state;
+            u32 m_protocol;
         public:
-            ICommunicationService() : state_event(nullptr), error_state(0) {
+            ICommunicationService() : state_event(nullptr), error_state(0), m_protocol(1) {
                 LogFormat("ICommunicationService");
                 /* ... */
             };
@@ -69,6 +70,7 @@ namespace ams::mitm::ldn {
 
             /*nyi----------------------------------------------------------------------------*/
             Result SetWirelessControllerRestriction();
+            Result SetProtocol(u32 protocol);
             Result ScanPrivate();
             Result CreateNetworkPrivate();
             Result Reject();


### PR DESCRIPTION
Stubs SetProtocol needed for Animal Crossing 3.0.0 LDN

SwitchBrew documentation: https://switchbrew.org/wiki/LDN_services#SetProtocol

Based on [PR #3329](https://git.eden-emu.dev/eden-emu/eden/pulls/3329) by Eden's Team made by Maufeat